### PR TITLE
Added help command to guide users with supported queries.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -109,6 +109,14 @@ chatbot_rules = {
         'intent': 'motivation'
     },
 
+    # Help
+    r".*\b(help)\b.*": {
+        'response': ("You can ask me about workouts, meals, sleep, and motivation. 🤖\n"
+                     "Try typing: 'workout plan', 'healthy meals', 'sleep tips', or 'motivate me'."),
+        'intent': 'help'
+    },
+
+
     # Polite Closings
     r".*\b(thank you|thanks)\b.*": {
         'response': "You're welcome! 🙌 Keep pushing towards your goals!",
@@ -121,7 +129,7 @@ chatbot_rules = {
 
     # Default
     "default": {
-        'response': "🤔 I'm not sure about that. Try asking about workouts, meals, or sleep.",
+        'response': "🤔 I'm not sure about that. Type 'help' to see what I can do!",
         'intent': 'unknown'
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+"streamlit" 


### PR DESCRIPTION
Solved issue: #40 
This pull request introduces a help command to improve usability of the chatbot.

Added a new regex rule to handle the help command.
When the user types help, the bot responds with a list of supported queries and examples.
Updated the default response to suggest typing help when the bot doesn’t understand a query.


Why this change?

New users may not know what kind of questions they can ask.
The help command improves discoverability of features and makes the chatbot easier to use.
Provides a clear entry point for interaction, especially for beginners.